### PR TITLE
Grr.  Need an empty string parameter when sourcing the conda environment

### DIFF
--- a/scripts/switch_gui.py
+++ b/scripts/switch_gui.py
@@ -28,7 +28,7 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-s","--switch", type=str,
-                       help="Name of switch")
+                        help="Name of switch", required=True)
 
     parser.add_argument("-u","--user",type=str,
                        help="Username for switch login")

--- a/scripts/switchtool
+++ b/scripts/switchtool
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export PCDS_CONDA_VER=5.4.2
-source /cds/group/pcds/pyps/conda/pcds_conda
+source /cds/group/pcds/pyps/conda/pcds_conda ""
 
 # Find full path of release directory.  This script is in
 # $RELDIR/scripts/launch_gui.sh, so we need to chop off the


### PR DESCRIPTION
Also, make -s required.  Sure, argparse still prints its description under optional arguments, but...
