### PR TITLE
ENH: add "Write Memory" button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+*.swp
+__pycache__
+build
+*.pyc
+*~
+
+#Coverage Reports
+htmlcov
+.coverage
+.cache
+
+*.egg-info
+logs
+
+# Sphinx
+docs/source/generated/*
+
+#pytest
+.pytest_cache
+.vscode

--- a/psnet/switch/switch.py
+++ b/psnet/switch/switch.py
@@ -680,7 +680,7 @@ class Switch(netconfig.host.Host):
 
     def write_memory(self):
         """
-        Save the currenty config to the switch so that it persists after next reboot.
+        Save the current config to the switch so that it persists after next reboot.
         """
         # This is a privileged command: do we need/have the enable password?
         if not self._enablepw and self._surveyer().check_mode(self.name):

--- a/psnet/switch/switch.py
+++ b/psnet/switch/switch.py
@@ -42,8 +42,13 @@ def determine_type(nc, name):
                 module_logger.info("%s is a%s %s switch." % (name, "n" if s[0] in 'aeiou' else "", s))
                 return s
     except:
-        pass
-    return None
+        d = ""
+    raise RuntimeError(
+        f"Switch {name} is either an unsupported type or does not have "
+        "the switch type in its netconfig description. "
+        f'The description was "{d}", and the '
+        f"supported switch types are {', '.join(switch_types.keys())}. "
+    )
 
 """
 What do we have in here?

--- a/psnet/switch/switch.py
+++ b/psnet/switch/switch.py
@@ -700,8 +700,10 @@ class Switch(netconfig.host.Host):
             module_logger.info("Bad enable password!")
             self._enablepw = None
             out_code = 1
+            resp="Bad enable password"
         except Exception:
             out_code = 1
+            resp=""
         if out_code:
             module_logger.error(f"Write memory had an error: {resp}")
         else:

--- a/psnet/ui/widgets/switch.py
+++ b/psnet/ui/widgets/switch.py
@@ -52,12 +52,15 @@ class SwitchWidget(QtWidgets.QWidget):
         self.move_button.clicked.connect(self.move_port)
         self.configure_button = QtWidgets.QPushButton('Auto Configure')
         self.configure_button.clicked.connect(self.auto_configure)
+        self.write_memory_button = QtWidgets.QPushButton('Write Memory')
+        self.write_memory_button.clicked.connect(self.write_memory)
         
         self.move_layout = QtWidgets.QHBoxLayout()
         self.move_layout.addWidget(self.refresh_button)
         self.move_layout.addWidget(self.survey_button)
         self.move_layout.addWidget(self.move_button)
         self.move_layout.addWidget(self.configure_button)
+        self.move_layout.addWidget(self.write_memory_button)
         
         self.utilities.setLayout(self.move_layout)
 
@@ -388,6 +391,12 @@ class SwitchWidget(QtWidgets.QWidget):
             for move in approved:
                 device,port,subnet = move
                 self._switch.move_device(device,subnet=subnet)
+
+    def write_memory(self):
+        """
+        Run the "write memory" command to make the switch config persist on boot.
+        """
+        self._switch.write_memory()
 
 
 class PyQtSwitch(Switch):

--- a/scripts/switch_gui.py
+++ b/scripts/switch_gui.py
@@ -18,12 +18,6 @@ def read_creds():
     return d
 
 def main():
-    log = logging.getLogger('psnet.switch')
-    stream = logging.StreamHandler()
-    stream.setLevel(logging.WARNING)
-    log.addHandler(stream)
-    creds = read_creds()
-
     #Parse arguments
     parser = argparse.ArgumentParser()
 
@@ -38,12 +32,20 @@ def main():
 
     parser.add_argument("-t","--timeout",type=float,
                        help="Timeout for switch refresh (hours, default 1)")
+    
+    parser.add_argument("-v","--verbose",action="count",default=0,
+                        help="Increase stderr logging verbosity for each v")
 
     kwargs = vars(parser.parse_args())
-    
     if not kwargs.get('switch'):
         print ('Use --switch argument to provide switch name')
         return None
+
+    log = logging.getLogger('psnet.switch')
+    stream = logging.StreamHandler()
+    stream.setLevel(max(0, logging.WARNING - 10 * kwargs["verbose"]))
+    log.addHandler(stream)
+    creds = read_creds()
 
     #Launch GUI
     app = QApplication(sys.argv)


### PR DESCRIPTION
From https://jira.slac.stanford.edu/browse/ECS-6631

There's no way in `switchtool` currently to run the "write memory" ("wr mem") command, which is normally used to make changes persist through a boot.

This PR implements the above via adding a "Write Memory" button and some internals to make it work.

![image](https://github.com/user-attachments/assets/2a72e24b-15a4-4d02-a128-3aab4b099b35)


This PR also implements:

- Add .gitignore
- Better error message when a switch's type cannot be determined (because I was having so much trouble figuring out why the tst switch in b901 wasn't working here)
- Add --verbose option for command-line output because the gui was crashing for me prior to opening the gui log and there was otherwise no way to see these pre-gui messages

Compromises made:
- Over the course of this PR I found and documented follow-up issues briefly in https://jira.slac.stanford.edu/browse/ECS-6694 which will need to be decomposed into multiple jiras
- Rather than enforce pep8, annotations, etc., myself, I "when in rome"'d this PR and followed the local style instead.
- This is not tested because we have beam right now and I don't have a usable test switch to test it on