### PR TITLE
missing self reference when accessing PORTCOL member

### DIFF
--- a/psnet/ui/widgets/vlan.py
+++ b/psnet/ui/widgets/vlan.py
@@ -38,7 +38,7 @@ class VlanWidget(QTableWidget):
                 self.set_name.emit(port.text(), new_name)
 
     def onPowerChanged(self, row, state):
-        port = self.item(row, PORTCOL)
+        port = self.item(row, self.PORTCOL)
         new_pwr = 1 if state == QtCore.Qt.Checked else 0
         if new_pwr != self._power[row]:
             self.set_power.emit(port.text(), new_pwr)


### PR DESCRIPTION
A really small bug I found when I was trying to power cycle a gige by disabling/enabling the poe state of its port (I later found out I don't have the secret password anyway). 

I got this exception
```
Traceback (most recent call last):
  File "/cds/group/pcds/pyps/apps/switchtool/R1.1.1/psnet/ui/widgets/vlan.py", line 41, in onPowerChanged
    port = self.item(row, PORTCOL)
NameError: name 'PORTCOL' is not defined
/cds/group/pcds/pyps/apps/switchtool/latest/switchtool: line 14: 21255 Aborted                 python $RELDIR/scripts/switch_gui.py "$@"
```
After adding self, it opens the password gui as expected. 

PORTCOL is a class variable but line 41 didn't reference it with "self." I did a cursory check of the other class_variables and they all have self. 
