### PR TITLE
Waiting to close ssh connection until socket is done sending data

### DIFF
--- a/psnet/survey/command.py
+++ b/psnet/survey/command.py
@@ -236,6 +236,19 @@ class CommandRunner(object):
             self.exit()
             return (self.chan.recv_exit_status(), output)
         finally:
+            # If we close without this, we sometimes get SSHExceptions when
+            # trying to reconnect. Get the exit status, then read everything from
+            # the socket until it's closed or get EOF from switch - at this point
+            # the connection should be closed and we should be able to reconnect
+            try:
+                sock = self.chan.get_transport().sock
+                sock.settimeout(self.timeout)
+                f = sock.makefile("rb")
+                _ = f.read()
+            except (OSError, socket.timeout) as e:
+                # OSError - connection closed while reading from socket
+                # socket.timeout - just timeout if we block for too long
+                pass
             self.ssh.close()
 
 


### PR DESCRIPTION
https://jira.slac.stanford.edu/browse/ECS-6845

If you open the switchtool gui or press refresh, you often get SSHExceptions like this
```
Exception (client): Error reading SSH protocol banner
Traceback (most recent call last):
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.2/lib/python3.9/site-packages/paramiko/transport.py", line 2271, in _check_banner
    buf = self.packetizer.readline(timeout)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.2/lib/python3.9/site-packages/paramiko/packet.py", line 380, in readline
    buf += self._read_timeout(timeout)
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.2/lib/python3.9/site-packages/paramiko/packet.py", line 609, in _read_timeout
    raise EOFError()
EOFError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.2/lib/python3.9/site-packages/paramiko/transport.py", line 2094, in run
    self._check_banner()
  File "/cds/group/pcds/pyps/conda/py39/envs/pcds-5.4.2/lib/python3.9/site-packages/paramiko/transport.py", line 2275, in _check_banner
    raise SSHException(
paramiko.ssh_exception.SSHException: Error reading SSH protocol banner
```
The exceptions happens when calling SSHClient.open
https://github.com/pcdshub/switchtool/blob/160f22bcf48b91243662a60c7a7fa5f5ed1c16f2/psnet/survey/command.py#L220
and is caught, but I believe that it's still printed because paramiko raises an SSHException while handling the initial EOFError, which I don't know can be silenced without changing the library. Why do we get this error in the first place? If you don't send the exit command to a switch but still call ssh.close you no longer get the error. Presumably the switch continues to do some cleanup of the ssh session after and trying to create a new connection during that time fails. I saw this on all switch types that switchtool supports except cisco, althought the only cisco switch I know of is switch-fee-far which I can't ping. I found some discussion about ssh bugs fixed by newer firmware on some forums discussing ruckus models, but I'm not sure if it would help in this case and I also think it'd be unreasonable to try and update all of our switches purely for qol. 

I could have just not called exit, but this felt unsatisfactory and also would have forced the removal of recv_exit_status (it would block forever since we are no longer exiting). I tried polling until the socket data was empty which worked, but I thought using the file descriptor looked a bit cleaner -  the read call will block until EOF (socket is done reading) or we timeout (so we can't ever block indefinitely) or we get OSError (if the socket closes before/during the read). I ran this on every switch that pings and two switches a few dozen times and it seems to work. I'm not 100% sure since it might just be a lot more unlikely because of the additional time spent before attempting a new connection, but I'm also not sure how to debug this on a lower level since it seems like it's all happening switch-side (the original error happens when paramiko expects to read the ssh banner but get a zero byte message instead). Happy to discuss alternative ways of trying to prevent this issue or to find out what causes it in more detail. 
