### PR TITLE
FIX: avoid index error in vlan accumulation

### DIFF
--- a/docs/source/upcoming_release_notes/8-ref_sdfconfig.rst
+++ b/docs/source/upcoming_release_notes/8-ref_sdfconfig.rst
@@ -25,4 +25,3 @@ Maintenance
 Contributors
 ------------
 - zllentz
-

--- a/docs/source/upcoming_release_notes/9-vlan_index_error.rst
+++ b/docs/source/upcoming_release_notes/9-vlan_index_error.rst
@@ -1,0 +1,23 @@
+9 vlan_index_error
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where if there are VLANs that don't have hyphens (`-`) in their name,
+  the GUI crashes.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/switchtool/sdfconfig.py
+++ b/switchtool/sdfconfig.py
@@ -10,15 +10,15 @@ at time of writing.
 """
 
 import functools
-import subprocess
 import json
+import subprocess
 
 
 @functools.lru_cache(maxsize=1000)
 def get_host_for_mac(mac_addr: str) -> str:
     """
     Returns the hostname associated with a mac_addr
-    
+
     Returns an empty string if the mac as not found.
 
     May raise if sdfconfig is not configured for the user.

--- a/switchtool/ui/widgets/switch.py
+++ b/switchtool/ui/widgets/switch.py
@@ -4,10 +4,10 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import QSettings, QTimer, pyqtSignal, pyqtSlot
 
 from ...EpicsQT.qlogdisplay import QLogDisplay
+from ...sdfconfig import get_subnet_for_host
 from ...switch.switch import Switch
 from .. import dialogs
 from .vlan import VlanWidget
-from ...sdfconfig import get_subnet_for_host
 
 
 class SwitchWidget(QtWidgets.QWidget):
@@ -17,11 +17,20 @@ class SwitchWidget(QtWidgets.QWidget):
     updated = pyqtSignal()
     update_port = pyqtSignal(str, str, str, str, str, str)
 
-    def __init__(self, switch, user="admin", pw=None, switch_type=None, timeout=1.0, parent=None):
+    def __init__(
+        self, switch, user="admin", pw=None, switch_type=None, timeout=1.0, parent=None
+    ):
         super().__init__(parent=parent)
         self.resize(660, 700)
 
-        self._switch = PyQtSwitch(switch, user=user, pw=pw, enablepw=None, switch_type=switch_type, parent=self)
+        self._switch = PyQtSwitch(
+            switch,
+            user=user,
+            pw=pw,
+            enablepw=None,
+            switch_type=switch_type,
+            parent=self,
+        )
         self.switch_name = switch.split(".")[0]
         self.refresh_timeout = timeout * 3600000  # Now ms!
 
@@ -109,7 +118,6 @@ class SwitchWidget(QtWidgets.QWidget):
         self.timer.timeout.connect(self.need_refresh)
         self.repaint()
         QTimer.singleShot(100, self.initial_update)
-
 
     def initial_update(self):
         self.updated.connect(self.refresh)
@@ -430,14 +438,24 @@ class SwitchWidget(QtWidgets.QWidget):
 
 
 class PyQtSwitch(Switch):
-    def __init__(self, switchname, user="admin", pw=None, enablepw=None, switch_type=None, parent=None):
+    def __init__(
+        self,
+        switchname,
+        user="admin",
+        pw=None,
+        enablepw=None,
+        switch_type=None,
+        parent=None,
+    ):
         self.parent = parent
         if pw is None:
-            pw = dialogs.passwddialog.getPassword(
-                "Password for {:}: ".format(user)
-            )
+            pw = dialogs.passwddialog.getPassword("Password for {:}: ".format(user))
         super().__init__(
-            switchname, user=user, pw=pw, enablepw=enablepw, switch_type=switch_type,
+            switchname,
+            user=user,
+            pw=pw,
+            enablepw=enablepw,
+            switch_type=switch_type,
         )
 
     def update(self):

--- a/switchtool/ui/widgets/switch.py
+++ b/switchtool/ui/widgets/switch.py
@@ -326,12 +326,21 @@ class SwitchWidget(QtWidgets.QWidget):
                 sub = "PCDSN-CDS-LAS"
                 if sub in allsubs.keys():
                     vl.append(allsubs[sub])
+                cds_vl = []
+                fez_vl = []
                 for v in vlist:
-                    if v not in vl and allvlan[v].split("-")[1] == "CDS":
-                        vl.append(v)
-                for v in vlist:
-                    if v not in vl and allvlan[v].split("-")[1] == "FEZ":
-                        vl.append(v)
+                    if v in vl:
+                        continue
+                    try:
+                        vlan_type = allvlan[v].split("-")[1]
+                    except IndexError:
+                        vlan_type = "NO_TYPE"
+                    if vlan_type == "CDS":
+                        cds_vl.append(v)
+                    elif vlan_type == "FEZ":
+                        fez_vl.append(v)
+                vl.extend(cds_vl)
+                vl.extend(fez_vl)
                 self._vlanList = vl
 
         # Now, go through the prefered vlan list order.  Add the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fix an issue with parsing vlan names without "-" in them- for now, ignore these
Try to keep the overall behavior the same, including order added to the list

Also run pre-commit to solve one of the CI build errors

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was crashing the gui for xpp
```
$ switchtool -s swh-xpp-h3
Traceback (most recent call last):
  File "/cds/group/pcds/pyps/apps/switchtool/R2.0.0/switchtool/ui/widgets/switch.py", line 330, in refresh
    if v not in vl and allvlan[v].split("-")[1] == "CDS":
                       ~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
/cds/group/pcds/pyps/apps/switchtool/latest/scripts/switchtool: line 17: 1058446 Aborted                 (core dumped) python "$RELDIR"/scripts/switch_gui.py "$@"
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
