### PR TITLE
MNT: connect debug/verbose switch to command runner internals

### DIFF
--- a/docs/source/upcoming_release_notes/10-mnt_more_debug.rst
+++ b/docs/source/upcoming_release_notes/10-mnt_more_debug.rst
@@ -1,0 +1,22 @@
+10 mnt_more_debug
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Extend the verbose flag to show additional debug information in terminal.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/scripts/switch_gui.py
+++ b/scripts/switch_gui.py
@@ -61,10 +61,15 @@ def main():
         print("Use --switch argument to provide switch name")
         return None
 
+    log_level = max(0, logging.WARNING - 10 * kwargs["verbose"])
+    # In the GUI
     log = logging.getLogger("switchtool.switch")
     stream = logging.StreamHandler()
-    stream.setLevel(max(0, logging.WARNING - 10 * kwargs["verbose"]))
+    stream.setLevel(log_level)
     log.addHandler(stream)
+    # In the terminal
+    if log_level < logging.INFO:
+        logging.basicConfig(level=log_level)
     creds = read_creds()
 
     # Launch GUI

--- a/switchtool/survey/command.py
+++ b/switchtool/survey/command.py
@@ -24,6 +24,7 @@ from .settings import (
 )
 
 LOG = logging.getLogger(LOG_CONF.get("logger_name", __name__))
+logger = logging.getLogger(__name__)
 
 
 class TelnetCommandRunner(object):
@@ -110,7 +111,6 @@ class CommandRunner(object):
         self.mode = ""
         self._config()
         self._rbuffer = None
-        self.debug = False
 
     def _config(self):
         self.ssh = paramiko.SSHClient()
@@ -169,8 +169,7 @@ class CommandRunner(object):
                     self._rbuffer = None
                 else:
                     self._rbuffer = self._rbuffer[idx + 1 :]
-                if self.debug:
-                    print("<<< %s" % r)
+                logger.debug("<<< %s" % r)
                 return r
             except:
                 # If there isn't a newline, try to read more.  If there
@@ -187,15 +186,13 @@ class CommandRunner(object):
                 if not didread:
                     r = self._rbuffer.decode("utf-8")
                     self._rbuffer = None
-                    if self.debug:
-                        print("<<< %s" % r)
+                    logger.debug("<<< %s" % r)
                     return r
 
     def exec_cmd(self, cmd, keepOutput=True):
         seen_echo = False
         seen_prompt = False
-        if self.debug:
-            print(">>> %s\\n" % cmd)
+        logger.debug(">>> %s\\n" % cmd)
         self.chan.send("%s%s" % (cmd, self.terminator))
         output = ""
 
@@ -203,24 +200,28 @@ class CommandRunner(object):
             line = self._readline()
             prompt_match = self.prompt_pattern.match(line.rstrip())
             if prompt_match and prompt_match.group("cmd") == cmd:
+                logger.debug("Seen prompt and echo")
                 self.mode = prompt_match.group("mode")
                 seen_echo = True
+            else:
+                logger.debug(f"Not seen prompt and echo for {self.prompt_pattern}")
 
         while not seen_prompt:
             line = self._readline()
             page_cont = self.page_cont_pattern.match(line)
             if page_cont:
+                logger.debug("page continue seen")
                 self.chan.send(" %s" % self.terminator)
-                if self.debug:
-                    print(">>> \\n")
+                logger.debug(">>> \\n")
             else:
+                logger.debug("no page continue seen")
                 prompt_match = self.prompt_pattern.match(line)
-                if self.debug and prompt_match:
-                    print("prompt_match!")
                 if prompt_match:
+                    logger.debug("prompt_match!")
                     self.mode = prompt_match.group("mode")
                     seen_prompt = True
                 else:
+                    logger.debug("no prompt match")
                     output += line
         self.chan.send(" %s" % self.terminator)
         if keepOutput:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There's a `-v` switch in the cli that is used to change which messages show up in the log widget.
This extends the functionality of the `-v` switch so that after a few `-vvv` s we start seeing all debug messages in the terminal- even those from other modules, etc.
Then I took some places in the code where debugging was done via a source code editable switch and switched these to using the python logger.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was trying to debug some switchtool issues and couldn't figure it out, but now there's pretty good debug messages with -vvv:
```
DEBUG:switchtool.survey.command:>>> show vlan\n
DEBUG:switchtool.survey.command:<<< SSH@swh-portable-01>show vlan

DEBUG:switchtool.survey.command:Not seen prompt and echo for re.compile('^SSH@swh-portable-det-01(?:\\([-/\\w]*\\))?(?P<mode>[#>])(?P<cmd>.*)')
DEBUG:switchtool.survey.command:<<<

DEBUG:switchtool.survey.command:Not seen prompt and echo for re.compile('^SSH@swh-portable-det-01(?:\\([-/\\w]*\\))?(?P<mode>[#>])(?P<cmd>.*)')
DEBUG:switchtool.survey.command:<<< Total PORT-VLAN entries: 18

DEBUG:switchtool.survey.command:Not seen prompt and echo for re.compile('^SSH@swh-portable-det-01(?:\\([-/\\w]*\\))?(?P<mode>[#>])(?P<cmd>.*)')
DEBUG:switchtool.survey.command:<<< Maximum PORT-VLAN entries: 1024
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
