### PR TITLE
FIX: be more forgiving with prompts

### DIFF
--- a/docs/source/upcoming_release_notes/11-fix_forgiving_prompts.rst
+++ b/docs/source/upcoming_release_notes/11-fix_forgiving_prompts.rst
@@ -1,0 +1,22 @@
+11 fix_forgiving_prompts
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Allow switchtool to accept switches whose internal hostnames do not match their DNS names.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/switchtool/survey/command.py
+++ b/switchtool/survey/command.py
@@ -231,7 +231,7 @@ class CommandRunner(object):
         Runs the command on the passed list of hosts
         """
         # Sigh... now we want to actually see if our prompt is '>' or '#' and enable if needed!
-        self.prompt_pattern = re.compile(self.prompt_temp % (host, "(?P<mode>[#>])"))
+        self.prompt_pattern = re.compile(self.prompt_temp % "(?P<mode>[#>])")
         output = ""
 
         # The connect seems to fail a lot.  Let's see if we can catch this at all
@@ -298,7 +298,7 @@ class AristaCommandRunner(CommandRunner):
             enablepw,
             port,
             cmds,
-            r"^%s(?:\.ARISTA)?%s(?P<cmd>.*)",
+            r"^\S+(?:\.ARISTA)?%s(?P<cmd>.*)",
             "\n",
             timeout,
             private_key,
@@ -331,7 +331,7 @@ class CiscoCommandRunner(CommandRunner):
             enablepw,
             port,
             cmds,
-            "^%s%s(?P<cmd>.*)",
+            r"^\S+%s(?P<cmd>.*)",
             "\n",
             timeout,
             private_key,
@@ -360,7 +360,7 @@ class BrocadeCommandRunner(CommandRunner):
             enablepw,
             port,
             cmds,
-            r"^SSH@%s(?:\([\w-]*\))?%s(?P<cmd>.*)",
+            r"^SSH@\S+(?:\([\w-]*\))?%s(?P<cmd>.*)",
             "\r\n",
             timeout,
             private_key,
@@ -397,7 +397,7 @@ class RuckusCommandRunner(CommandRunner):
             enablepw,
             port,
             cmds,
-            r"^SSH@%s(?:\([-/\w]*\))?%s(?P<cmd>.*)",
+            r"^SSH@\S+(?:\([-/\w]*\))?%s(?P<cmd>.*)",
             "\n",
             timeout,
             private_key,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove the hostname from the prompt specifiers, replacing it with a general \S+ match, which should match any hostname.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, we were parsing the switch output by checking for an exact prompt match that would include the switch's DNS name. But for some switches these do not match and this resolves the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

I am somewhat worried that this should be tested more

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
